### PR TITLE
Fiji url fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-portal",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "dependencies": {
     "@babel/preset-typescript": "^7.21.5",

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -88,8 +88,8 @@ export const getStage = () => {
   if (maybeDev === 'dev') {
     return maybeDev
   }
-  else if (maybeDev === 'prod') {
-    return maybeDev
+  else if (maybeDev === 'prod' || maybeDev === undefined) {
+    return 'prod'
   }
   else {
     throw new Error('Failed to parse environment variable REACT_APP_STAGE. It should be one of ["dev", "prod"]')

--- a/src/components/DatasetDescriptionText.tsx
+++ b/src/components/DatasetDescriptionText.tsx
@@ -140,7 +140,7 @@ export function DatasetAcquisition({
           <p>
             <strong>
               Imaging start date
-            </strong>:{acq.startDate ? new Date(acq.startDate).toDateString() : ' Unknown'}
+            </strong>: {(acq.startDate ? new Date(acq.startDate).toDateString() : 'Unknown')}
           </p>
           <p>
             <strong>Final voxel size ({acq.gridSpacingUnit})</strong>


### PR DESCRIPTION
fixes FIJI links by checking for the container format (zarr or n5) with the most associated images, and generating a URL based on that. Something to hold us over until we do the right thing (associate a FIJI link per image, instead of per-dataset)