### PR TITLE
Remove redundant setSearched function

### DIFF
--- a/src/components/DatasetLayout.tsx
+++ b/src/components/DatasetLayout.tsx
@@ -52,7 +52,7 @@ export default function DatasetLayout({
   const classes = useStyles();
   const history = useHistory();
   const page = parseInt(query.get("page") || "1");
-  const { appState, setPermanent, setSearched} = useContext(AppContext);
+  const { appState, setPermanent} = useContext(AppContext);
 
   const { datasetGrid: compact } = appState;
   const datasetsPerPage = compact ? 12 : 10;
@@ -161,7 +161,7 @@ export default function DatasetLayout({
   };
 
   const handleSearchChange = (event: React.ChangeEvent<{value: unknown}>) => {
-    setSearched({searchFilter: event.target.value as string});
+    setPermanent({searchFilter: event.target.value as string});
   };
 
   if (datasets.size < 1) {

--- a/src/components/DatasetPaper.tsx
+++ b/src/components/DatasetPaper.tsx
@@ -69,7 +69,7 @@ export default function DatasetPaper({ datasetKey }: DatasetPaperProps) {
   const [viewChecked, setViewChecked] = useState(0)
  
   if (datasetsLoader.isLoading || viewsLoader.isLoading) {
-    return <>Loading metadatata....</>
+    return <>Loading metadata....</>
   }
 
   else if (datasetsLoader.error || viewsLoader.error) {

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -19,7 +19,6 @@ interface AppContext {
   appState: ContextProps
   setAppState: (appState: ContextProps) => null | void
   setPermanent: (action: any) => null | void
-  setSearched: (action: any) => null | void
 }
 
 const contextDefault: ContextProps = {
@@ -43,7 +42,6 @@ const AppContext = React.createContext<AppContext>({
   appState: combinedState,
   setAppState: () => null,
   setPermanent: () => null,
-  setSearched: () => null,
 });
 
 const AppProvider = (props: any) => {
@@ -64,24 +62,8 @@ const AppProvider = (props: any) => {
     setAppState({ ...appState, ...action });
   }
 
-  const setSearched = (action : any) => {
-    const searchedByNameState = Object.keys(appState)
-      .filter(key => allowedPermanent.includes(key))
-        .reduce((obj, key) => {
-          return {
-            ...obj,
-            [key]: appState[key]
-          }
-        }, {});
-
-    const updatedState = { ...searchedByNameState, ...action};
-    localStorage.setItem("appState", JSON.stringify(updatedState));
-    setAppState({ ...appState, ...action });
-  }
-
-
   return (
-    <AppContext.Provider value={{appState, setAppState, setPermanent, setSearched}}>
+    <AppContext.Provider value={{appState, setAppState, setPermanent}}>
       {children}
     </AppContext.Provider>
   );


### PR DESCRIPTION
Remove redundant setSearched function. The state of the dataset search field could be defined with setPermanent, which would be passed to the handleSearchChange instead of setSearched function.  