### PR TITLE
Implement image stack for the React checkbox component in neuroglancer layer selection panel on openorganelle.com/datasets/dataset_name

### DIFF
--- a/src/api/datasets.ts
+++ b/src/api/datasets.ts
@@ -131,6 +131,7 @@ async function queryDatasets(){
                 institution,
                 created_at,
                 stage,
+                image_stack,
                 meshes:mesh(
                     name,
                     description,

--- a/src/api/neuroglancer.ts
+++ b/src/api/neuroglancer.ts
@@ -191,7 +191,8 @@ export function makeNeuroglancerUrl({position,
                                       images,
                                       outputDimensions,
                                       host} : viewToNeuroglancerUrlProps) {
-    const layers = images.map(im => {
+    
+    const layers = images.reverse().map(im => {
         const layerType = (im.sampleType === 'scalar') ? 'image' : 'segmentation';
         return makeLayer(im, layerType, outputDimensions);
       });

--- a/src/api/views.ts
+++ b/src/api/views.ts
@@ -30,6 +30,7 @@ export async function fetchViews() {
         content_type,
         institution,
         created_at,
+        image_stack,
         meshes:mesh(
             name,
             description,

--- a/src/components/DatasetPaper.tsx
+++ b/src/components/DatasetPaper.tsx
@@ -144,6 +144,25 @@ export default function DatasetPaper({ datasetKey }: DatasetPaperProps) {
     }
     setImageChecked(newImageChecked)
     }
+  
+  const handleImageStackChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newImageChecked = new Set([...imageChecked])
+    const groupImagesNames = new Set(dataset.images.filter( image => image.contentType === event.target.name).map(v => v.name)) 
+    if (event.target.checked) {
+      for (const imageName of groupImagesNames) {
+        newImageChecked.add(imageName)
+      }
+    }
+    else {
+      // prevent all image checkboxes from being deselected
+      if (newImageChecked.size > 1) {
+        for (const imageName of groupImagesNames) {
+          newImageChecked.delete(imageName)
+        }
+      }
+    }
+    setImageChecked(newImageChecked)
+    }
 
   const handleViewChange = (index: number, views: View[]) => () => {
     const newImageState = views[index].images.reduce((previous, current) =>
@@ -219,6 +238,7 @@ export default function DatasetPaper({ datasetKey }: DatasetPaperProps) {
                 dataset={dataset}
                 checkState={imageChecked}
                 handleImageChange={handleImageChange}
+                handleImageStackChange={handleImageStackChange}
                 handleFilterChange={handleFilterChange}
                 filter={layerFilter}
               />

--- a/src/components/DatasetPaper.tsx
+++ b/src/components/DatasetPaper.tsx
@@ -131,23 +131,10 @@ export default function DatasetPaper({ datasetKey }: DatasetPaperProps) {
   if (imageChecked.size == 0) {
     inView.forEach(name => imageChecked.add(name))
   }
-  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newImageChecked = new Set([...imageChecked])
-    if (event.target.checked) {
-      newImageChecked.add(event.target.name)
-    }
-    else {
-      // prevent all image checkboxes from being deselected
-      if (newImageChecked.size > 1) {
-        newImageChecked.delete(event.target.name)
-      }
-    }
-    setImageChecked(newImageChecked)
-    }
   
   const handleImageStackChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newImageChecked = new Set([...imageChecked])
-    const groupImagesNames = new Set(dataset.images.filter( image => image.contentType === event.target.name).map(v => v.name)) 
+    const groupImagesNames = new Set(dataset.images.filter( image => image.imageStack === event.target.name).map(v => v.name)) 
     if (event.target.checked) {
       for (const imageName of groupImagesNames) {
         newImageChecked.add(imageName)
@@ -237,7 +224,6 @@ export default function DatasetPaper({ datasetKey }: DatasetPaperProps) {
               <LayerCheckboxList
                 dataset={dataset}
                 checkState={imageChecked}
-                handleImageChange={handleImageChange}
                 handleImageStackChange={handleImageStackChange}
                 handleFilterChange={handleFilterChange}
                 filter={layerFilter}

--- a/src/components/LayerCheckboxList.tsx
+++ b/src/components/LayerCheckboxList.tsx
@@ -32,7 +32,6 @@ const useStyles: any = makeStyles(() =>
 interface LayerCheckboxListProps {
   dataset: Dataset;
   checkState: Set<string>;
-  handleImageChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleImageStackChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleFilterChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   filter: string | undefined;
@@ -41,7 +40,6 @@ interface LayerCheckboxListProps {
 interface FilteredLayerListProps {
   dataset: Dataset;
   checkState: Set<string>;
-  handleImageChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleImageStackChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   filter: string | undefined;
 }
@@ -51,7 +49,7 @@ interface LayerFilterProps {
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
 }
 
-function FilteredLayersList({ dataset, checkState, handleImageChange, handleImageStackChange, filter}: FilteredLayerListProps) {
+function FilteredLayersList({ dataset, checkState, handleImageStackChange, filter}: FilteredLayerListProps) {
   const classes = useStyles();
   const imagesInit: Image[] = []
   const [images, setImages] = useState(imagesInit);
@@ -88,7 +86,6 @@ function FilteredLayersList({ dataset, checkState, handleImageChange, handleImag
               key={ct}
               images={images}
               checkState={checkState}
-              handleImageChange={handleImageChange}
               handleImageStackChange={handleImageStackChange}
               contentType={ct}
               contentTypeInfo={contentTypeInfo}
@@ -126,7 +123,6 @@ function LayerFilter({ value, onChange } : LayerFilterProps) {
 export default function LayerCheckboxList({
   dataset,
   checkState,
-  handleImageChange,
   handleImageStackChange,
   handleFilterChange,
   filter,
@@ -139,7 +135,6 @@ export default function LayerCheckboxList({
       <FilteredLayersList
         dataset={dataset}
         checkState={checkState}
-        handleImageChange={handleImageChange}
         handleImageStackChange={handleImageStackChange}
         filter={filter}
       />

--- a/src/components/LayerCheckboxList.tsx
+++ b/src/components/LayerCheckboxList.tsx
@@ -33,6 +33,7 @@ interface LayerCheckboxListProps {
   dataset: Dataset;
   checkState: Set<string>;
   handleImageChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleImageStackChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleFilterChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   filter: string | undefined;
 }
@@ -41,6 +42,7 @@ interface FilteredLayerListProps {
   dataset: Dataset;
   checkState: Set<string>;
   handleImageChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleImageStackChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   filter: string | undefined;
 }
 
@@ -49,7 +51,7 @@ interface LayerFilterProps {
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
 }
 
-function FilteredLayersList({ dataset, checkState, handleImageChange, filter}: FilteredLayerListProps) {
+function FilteredLayersList({ dataset, checkState, handleImageChange, handleImageStackChange, filter}: FilteredLayerListProps) {
   const classes = useStyles();
   const imagesInit: Image[] = []
   const [images, setImages] = useState(imagesInit);
@@ -87,6 +89,7 @@ function FilteredLayersList({ dataset, checkState, handleImageChange, filter}: F
               images={images}
               checkState={checkState}
               handleImageChange={handleImageChange}
+              handleImageStackChange={handleImageStackChange}
               contentType={ct}
               contentTypeInfo={contentTypeInfo}
               accordionExpanded={expanded}/>;
@@ -124,6 +127,7 @@ export default function LayerCheckboxList({
   dataset,
   checkState,
   handleImageChange,
+  handleImageStackChange,
   handleFilterChange,
   filter,
 }: LayerCheckboxListProps) {
@@ -136,6 +140,7 @@ export default function LayerCheckboxList({
         dataset={dataset}
         checkState={checkState}
         handleImageChange={handleImageChange}
+        handleImageStackChange={handleImageStackChange}
         filter={filter}
       />
     </>

--- a/src/components/LayerGroup.tsx
+++ b/src/components/LayerGroup.tsx
@@ -12,6 +12,7 @@ interface ImageCheckboxCollectionProps {
   images: Image[]
   checkState: Set<string>
   handleImageChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  handleImageStackChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   contentType: string,
   contentTypeInfo: ContentTypeMetadata,
   accordionExpanded: boolean
@@ -24,6 +25,7 @@ export default function ImageCheckboxCollection({
   images,
   checkState,
   handleImageChange,
+  handleImageStackChange,
   contentType,
   contentTypeInfo,
   accordionExpanded,
@@ -41,14 +43,14 @@ export default function ImageCheckboxCollection({
         control={
           <Checkbox
             checked={checkState.has(images[0].name)}
-            onChange={handleImageChange}
+            onChange={handleImageStackChange}
             color="primary"
-            name={images[0].name}
+            name={contentType}
             size="small"
           />
         }
         label={"Ground truth"}
-        key={`${images[0].name}`}
+        key={contentType}//{`${images[0].name}`}
       />
     )
   }

--- a/src/components/LayerGroup.tsx
+++ b/src/components/LayerGroup.tsx
@@ -34,23 +34,43 @@ export default function ImageCheckboxCollection({
     setExpanded(!expanded);
   };
 
-  const checkBoxList = images?.map((image: Image) => {
-    return (
+  let checkBoxList : Array<object> = [];
+  if (images.every((image : Image) => image.contentType === 'annotation')){
+    checkBoxList.push(
       <FormControlLabel
         control={
           <Checkbox
-            checked={checkState.has(image.name)}
+            checked={checkState.has(images[0].name)}
             onChange={handleImageChange}
             color="primary"
-            name={image.name}
+            name={images[0].name}
             size="small"
           />
         }
-        label={image.description}
-        key={`${image.name}`}
+        label={"Ground truth"}
+        key={`${images[0].name}`}
       />
-    );
-  });
+    )
+  }
+  else {
+    checkBoxList = images?.map((image: Image) => {
+      return (
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={checkState.has(image.name)}
+              onChange={handleImageChange}
+              color="primary"
+              name={image.name}
+              size="small"
+            />
+          }
+          label={image.description}
+          key={`${image.name}`}
+        />
+      );
+    });
+  }
 
   return (
     <Accordion key={contentType} expanded={expanded} onChange={handleExpand}>

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -84,6 +84,7 @@ export type ImageQueryResult = {
   dataset_name: string
   institution: string
   stage: Stage
+  image_stack: string
   meshes: {
     name: string
     description: string

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -128,6 +128,7 @@ export interface Database {
           source: Json | null
           stage: Database["public"]["Enums"]["stage"]
           url: string
+          image_stack: string
         }
         Insert: {
           content_type: Database["public"]["Enums"]["content_type"]
@@ -148,6 +149,7 @@ export interface Database {
           source?: Json | null
           stage?: Database["public"]["Enums"]["stage"]
           url: string
+          image_stack: string
         }
         Update: {
           content_type?: Database["public"]["Enums"]["content_type"]
@@ -168,6 +170,7 @@ export interface Database {
           source?: Json | null
           stage?: Database["public"]["Enums"]["stage"]
           url?: string
+          image_stack?: string
         }
         Relationships: [
           {


### PR DESCRIPTION
- Checkbox React element now represents not a single volumetric image but a stack of images. 
- Each stack defined through unique tag in the image_stack column of the supabase image table.
- Modified handleImageStackChange() - add images to a neuroglancer layers list through filtering by image_stack tag.
- Removed handleImageChange()